### PR TITLE
Nix bootstrap: 最小構成の flake.nix と .nix-setup.sh を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 Brewfile.lock.json
 
+# Nix
+result
+result-*
+
 DOT_LINK_TARGET/config/fish/functions/fisher.fish
 DOT_LINK_TARGET/config/fisher/
 DOT_LINK_TARGET/claude/skills/best-practice/.last-run

--- a/.nix-setup.sh
+++ b/.nix-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+set -o pipefail
+
+# 最小 Nix セットアップ:
+# 1. Nix が未インストールなら Determinate Systems インストーラで導入
+# 2. flake.nix の default パッケージを nix profile に install
+#
+# init.sh からは呼ばない（Nix 導入はホスト全体に影響する大きな副作用のため）。
+# 利用者が明示的に `bash .nix-setup.sh` を実行する想定。
+
+cd "$(dirname "$0")"
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "[*] Installing Nix via Determinate Systems installer..."
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate
+  # インストール直後の現シェルでは nix コマンドにパスが通っていないため source する
+  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    # shellcheck disable=SC1091
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+  fi
+else
+  echo "[*] Nix is already installed: $(nix --version)"
+fi
+
+echo "[*] Installing CLI tools from flake (.#default)..."
+nix --extra-experimental-features 'nix-command flakes' \
+  profile install ".#default"
+
+echo "[*] Done. Verify with: nix profile list"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "ik11235 Dotfiles - minimal Nix bootstrap";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    systems = ["aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux"];
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+  in {
+    packages = forAllSystems (pkgs: {
+      default = pkgs.buildEnv {
+        name = "dotfiles-cli";
+        paths = with pkgs; [
+          alejandra
+          nil
+        ];
+      };
+    });
+
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+  };
+}


### PR DESCRIPTION
## Summary

- 既存の `feature/nix-migration` ブランチ(https://github.com/ik11235/Dotfile/pull/19 )が Phase 0〜6 を一気に取り込み、master との乖離が大きくなったため、0 ベースで段階的に再導入する 1st ステップ
- スコープは「Nix インストール + 最低限の設定移行」に限定。`nix-darwin` / `home-manager` / マルチマシン対応は導入しない
- 既存の `init.sh` / `.mac-init.sh` / `Brewfile` / dotfiles には触らない（既存運用と並走可能）

### 追加ファイル

| ファイル | 役割 |
| --- | --- |
| `flake.nix` | nixpkgs のみ依存。`packages.<system>.default` で `alejandra` (Nix フォーマッタ) と `nil` (Nix LSP) を `buildEnv` でまとめた最小パッケージ |
| `flake.lock` | nixpkgs を `nixpkgs-unstable` の特定 commit に固定 |
| `.nix-setup.sh` | Determinate Systems インストーラで Nix を導入し、`nix profile install '.#default'` を実行する手動スクリプト |
| `.gitignore` | `result` / `result-*` を追加 |

### 設計判断

- `init.sh` からは `.nix-setup.sh` を呼ばない。Nix 導入はホスト全体に影響する大きな副作用のため、利用者が明示的に `bash .nix-setup.sh` を実行する設計
- 管理対象は既存 `Brewfile` と衝突しない `alejandra` / `nil` のみ。CLI ツールの本格的な Nix 移行は次ステップ以降

### 次ステップの候補

- 2nd: 既存 `Brewfile` から CLI ツールを Nix 側へ寄せる
- 3rd: `nix-darwin` 導入（packages のみ、システム設定は触らない）
- 4th 以降: `home-manager` / `.mac-init.sh` 移行 / マルチマシン化 / CI

## Test plan

- [x] `nix flake check` が `packages.aarch64-darwin.default` と `formatter.aarch64-darwin` の評価まで通る
- [x] 実機で `bash .nix-setup.sh` を実行し、`nix profile list` に `dotfiles-cli` (store path) が出ることを確認
- [x] `alejandra --version` (Alejandra 4.0.0) / `nil --version` (nil 2025-06-13) が `~/.nix-profile/bin/` 経由で動くことを確認
- [x] 既存の `init.sh` 経由のセットアップに影響がないことを確認

Generated with Claude Code