### PR TITLE
ci: GitHub Actions のリファクタリングと checkout を v6 に更新

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,11 +6,16 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: actionlint
         uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/shellscript-syntax-check.yml
+++ b/.github/workflows/shellscript-syntax-check.yml
@@ -1,39 +1,30 @@
-# This is a basic workflow to help you get started with Actions
-
 name: shellscript-syntax-check
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches:
       - master
   pull_request:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  shellcheck:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      # install zsh
       - name: Install zsh and shellcheck
         run: |
           sudo apt-get update
           sudo apt-get install -y zsh shellcheck
 
-      # Runs a single command using the runners shell
       - name: zsh syntax check
         run: zsh -n DOT_LINK_TARGET/zshrc DOT_LINK_TARGET/zsh.d/zshrc_* DOT_LINK_TARGET/zsh.d/global/*.zsh
 
-      - name: init.sh syntax check
+      - name: bash syntax check
         run: bash -n ./*.sh
 
-      - name: run shellcheck
+      - name: shellcheck
         run: shellcheck ./*.sh DOT_LINK_TARGET/bin/*

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -6,11 +6,16 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: yamllint
         uses: reviewdog/action-yamllint@v1


### PR DESCRIPTION
## Summary
- `actions/checkout` を `@v4` → `@v6` に更新（v6.0.2 が最新メジャー）
- 最小権限の `permissions:` ブロックを各 workflow に追加
  - `shellscript-syntax-check`: `contents: read`
  - `yamllint` / `actionlint`: `contents: read` + `checks: write` + `pull-requests: write` (reviewdog の `github-pr-check` reporter 用)
- `shellscript-syntax-check.yml` の雛形由来の冗長コメントを削除、ジョブ名 `build` → `shellcheck`、ステップ名を実態に合わせて整理
- `reviewdog/action-yamllint@v1` / `reviewdog/action-actionlint@v1` は major タグが現役のため据え置き

## Test plan
- [x] ローカルで `yamllint -c .yamllint.yml .github/workflows/ DOT_LINK_TARGET/config/gh/config.yml .yamllint.yml` 通過
- [x] ローカルで `actionlint .github/workflows/*.yml` 通過 (exit 0)
- [x] CI 上で `shellscript-syntax-check` / `yamllint` / `actionlint` 3 workflow がすべて緑